### PR TITLE
update send from deno's breaking change

### DIFF
--- a/send.ts
+++ b/send.ts
@@ -151,7 +151,7 @@ export async function send(
     throw createHttpError(500, err.message);
   }
 
-  response.headers.set("Content-Length", String(stats.len));
+  response.headers.set("Content-Length", String(stats.size));
   if (!response.headers.has("Last-Modified") && stats.modified) {
     response.headers.set("Last-Modified", toUTCString(stats.modified));
   }


### PR DESCRIPTION
deno made a breaking change to FileInfo `len` is now `size`
The change is outlined here:https://github.com/denoland/deno/pull/4338

Issue in oak was open: https://github.com/oakserver/oak/issues/48